### PR TITLE
Motion 1: Make all paragraphs automatically numbered

### DIFF
--- a/statutes/paragraphs.tex
+++ b/statutes/paragraphs.tex
@@ -101,7 +101,6 @@ The association seeks to achieve its objectives by:
   \item Members have to pay the membership fee determined by the fall meeting.
 \end{enumerate}
 
-\setcounter{subsection}{14}
 \subsection{Termination of membership}
 Membership is terminated:
 \begin{enumerate}


### PR DESCRIPTION
This fixes the fact that there is no § 14. All paragraphs are now numbered sequentially from § 1.